### PR TITLE
Bilmur: improve tracking setup

### DIFF
--- a/includes/bilmur.php
+++ b/includes/bilmur.php
@@ -17,6 +17,11 @@ if ( ! defined( 'WPCOMSP_BILMUR_TRACKING' ) || ! WPCOMSP_BILMUR_TRACKING ) {
 function wpcomsp_bilmur_timezone_string() {
 	$wp_tz = wp_timezone_string();
 
+	// Handle empty strings.
+	if ( $wp_tz === '' ) {
+    return 'UTC';
+	}
+
 	// Did we get back an offset?
 	if ( preg_match( '/^([+-])?(\d{1,2}):(\d{2})$/', $wp_tz, $matches ) ) {
 		$sign = $matches[1] === '-' ? -1 : 1;
@@ -41,6 +46,14 @@ function wpcomsp_bilmur_timezone_string() {
 		// fractional offset, by simply discarding the fractional part.
 		// This isn't ideal, but there's no standard way of describing
 		// these offsets, and is likely to be an extreme edge case.
+		return 'Etc/GMT' . ( $sign === -1 ? '+' : '-' ) . $hours;
+	}
+
+	// Handle legacy “UTC±N” offsets as well.
+	if ( preg_match( '/^UTC([+-])(\d{1,2})$/i', $wp_tz, $matches ) ) {
+		$sign = $matches[1] === '-' ? -1 : 1;
+		$hours = intval( $matches[2], 10 );
+
 		return 'Etc/GMT' . ( $sign === -1 ? '+' : '-' ) . $hours;
 	}
 

--- a/includes/bilmur.php
+++ b/includes/bilmur.php
@@ -18,20 +18,20 @@ function wpcomsp_bilmur_timezone_string() {
 	$wp_tz = wp_timezone_string();
 
 	// Handle empty strings.
-	if ( $wp_tz === '' ) {
+	if ( '' === $wp_tz ) {
 		return 'UTC';
 	}
 
 	// Did we get back an offset?
 	if ( preg_match( '/^([+-])?(\d{1,2}):(\d{2})$/', $wp_tz, $matches ) ) {
-		$sign = $matches[1] === '-' ? -1 : 1;
-		$hours = intval( $matches[2], 10 );
+		$sign    = '-' === $matches[1] ? -1 : 1;
+		$hours   = intval( $matches[2], 10 );
 		$minutes = intval( $matches[3], 10 );
 
 		// For fractional hour offsets, use `timezone_name_from_abbr` to get a
 		// matching "<Area>/<City>" timezone.
 		if ( $minutes > 0 ) {
-			$offset = $sign * ( $hours * 3600 + $minutes * 60 );
+			$offset  = $sign * ( $hours * 3600 + $minutes * 60 );
 			$city_tz = timezone_name_from_abbr( '', $offset, 0 );
 
 			if ( ! empty( $city_tz ) ) {
@@ -46,15 +46,15 @@ function wpcomsp_bilmur_timezone_string() {
 		// fractional offset, by simply discarding the fractional part.
 		// This isn't ideal, but there's no standard way of describing
 		// these offsets, and is likely to be an extreme edge case.
-		return 'Etc/GMT' . ( $sign === -1 ? '+' : '-' ) . $hours;
+		return 'Etc/GMT' . ( -1 === $sign ? '+' : '-' ) . $hours;
 	}
 
 	// Handle legacy “UTC±N” offsets as well.
 	if ( preg_match( '/^UTC([+-])(\d{1,2})$/i', $wp_tz, $matches ) ) {
-		$sign = $matches[1] === '-' ? -1 : 1;
+		$sign  = '-' === $matches[1] ? -1 : 1;
 		$hours = intval( $matches[2], 10 );
 
-		return 'Etc/GMT' . ( $sign === -1 ? '+' : '-' ) . $hours;
+		return 'Etc/GMT' . ( -1 === $sign ? '+' : '-' ) . $hours;
 	}
 
 	// For anything that's not an offset, return the string we got from WP.
@@ -66,7 +66,7 @@ function wpcomsp_bilmur_timezone_string() {
  */
 add_action(
 	'wp_enqueue_scripts',
-	static function() {
+	static function () {
 		// Request a new version of bilmur every week.
 		// This keeps bilmur up-to-date independently of CDN caching times.
 		$weekly_cachebust = 'm=' . gmdate( 'YW' );
@@ -79,21 +79,32 @@ add_action(
 		// Base URL for bilmur script.
 		$bilmur_url = 'https://s0.wp.com/wp-content/js/bilmur.min.js';
 
-		wp_enqueue_script( 'bilmur', $bilmur_url . '?' . $weekly_cachebust, array(), $manual_version, array( 'strategy' => 'defer', 'in_footer' => true ) );
+		wp_enqueue_script(
+			'bilmur',
+			$bilmur_url . '?' . $weekly_cachebust,
+			array(),
+			$manual_version,
+			array(
+				'strategy'  => 'defer',
+				'in_footer' => true,
+			)
+		);
 	}
 );
 
 // Add bilmur config to page for the script to pick up when it runs.
 add_action(
 	'wp_footer',
-	function() {
+	function () {
 		$custom_properties = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
 
 		if ( ! defined( 'WPCOMSP_BILMUR_PROVIDER' ) || ! defined( 'WPCOMSP_BILMUR_SERVICE' ) ) {
 			return;
 		}
+
 		// Is the WooCommerce plugin active?
 		$woo_active = class_exists( 'WooCommerce' ) ? '1' : '0';
+
 		$custom_properties['woo_active'] = $woo_active;
 
 		?>
@@ -101,10 +112,10 @@ add_action(
 				id="bilmur"
 				property="bilmur:data"
 				content=""
-				data-provider="<?php echo esc_attr( WPCOMSP_BILMUR_PROVIDER ) ?>"
-				data-service="<?php echo esc_attr( WPCOMSP_BILMUR_SERVICE ) ?>"
-				data-custom-props="<?php echo esc_attr( wp_json_encode( $custom_properties ) ) ?>"
-				data-site-tz="<?php echo esc_attr( wpcomsp_bilmur_timezone_string() ) ?>"
+				data-provider="<?php echo esc_attr( WPCOMSP_BILMUR_PROVIDER ); ?>"
+				data-service="<?php echo esc_attr( WPCOMSP_BILMUR_SERVICE ); ?>"
+				data-custom-props="<?php echo esc_attr( wp_json_encode( $custom_properties ) ); ?>"
+				data-site-tz="<?php echo esc_attr( wpcomsp_bilmur_timezone_string() ); ?>"
 			>
 		<?php
 	}

--- a/includes/bilmur.php
+++ b/includes/bilmur.php
@@ -19,7 +19,7 @@ function wpcomsp_bilmur_timezone_string() {
 
 	// Handle empty strings.
 	if ( $wp_tz === '' ) {
-    return 'UTC';
+		return 'UTC';
 	}
 
 	// Did we get back an offset?

--- a/includes/bilmur.php
+++ b/includes/bilmur.php
@@ -89,6 +89,9 @@ add_action(
 	function() {
 		$custom_properties = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
 
+		if ( ! defined( 'WPCOMSP_BILMUR_PROVIDER' ) || ! defined( 'WPCOMSP_BILMUR_SERVICE' ) ) {
+			return;
+		}
 		// Is the WooCommerce plugin active?
 		$woo_active = class_exists( 'WooCommerce' ) ? '1' : '0';
 		$custom_properties['woo_active'] = $woo_active;

--- a/includes/bilmur.php
+++ b/includes/bilmur.php
@@ -7,33 +7,89 @@ if ( ! defined( 'WPCOMSP_BILMUR_TRACKING' ) || ! WPCOMSP_BILMUR_TRACKING ) {
 	return;
 }
 
+// Returns a standardized timezone string.
+//
+// `wp_timezone_string()` sometimes returns offsets (e.g. "-07:00"), which are
+// a non-standard representation of a UTC offset that only works in PHP.
+// This function returns a standardized timezone string instead, of the form
+// "Etc/GMT+7" for integer hour offsets, or a matching "<Area>/<City>" form for
+// fractional hour offsets (used e.g. in India).
+function wpcomsp_bilmur_timezone_string() {
+	$wp_tz = wp_timezone_string();
+
+	// Did we get back an offset?
+	if ( preg_match( '/^([+-])?(\d{1,2}):(\d{2})$/', $wp_tz, $matches ) ) {
+		$sign = $matches[1] === '-' ? -1 : 1;
+		$hours = intval( $matches[2], 10 );
+		$minutes = intval( $matches[3], 10 );
+
+		// For fractional hour offsets, use `timezone_name_from_abbr` to get a
+		// matching "<Area>/<City>" timezone.
+		if ( $minutes > 0 ) {
+			$offset = $sign * ( $hours * 3600 + $minutes * 60 );
+			$city_tz = timezone_name_from_abbr( '', $offset, 0 );
+
+			if ( ! empty( $city_tz ) ) {
+				return $city_tz;
+			}
+		}
+
+		// For integer hour offsets, use "Etc/GMT(+|-)<offset>".
+		// The sign is flipped, to match how the `Etc` area is specced.
+		//
+		// This codepath is also followed if no city exists to match a
+		// fractional offset, by simply discarding the fractional part.
+		// This isn't ideal, but there's no standard way of describing
+		// these offsets, and is likely to be an extreme edge case.
+		return 'Etc/GMT' . ( $sign === -1 ? '+' : '-' ) . $hours;
+	}
+
+	// For anything that's not an offset, return the string we got from WP.
+	return $wp_tz;
+}
+
 /**
  * Bilmur RUM data collector
  */
 add_action(
 	'wp_enqueue_scripts',
 	static function() {
-		wp_enqueue_script( 'bilmur', 'https://s0.wp.com/wp-content/js/bilmur.min.js?m=202215', array(), '1.0.0', true );
+		// Request a new version of bilmur every week.
+		// This keeps bilmur up-to-date independently of CDN caching times.
+		$weekly_cachebust = 'm=' . gmdate( 'YW' );
+
+		// Allow for manually forcing a new version of bilmur with a plugin update.
+		// Useful in case bilmur needs to be updated outside of the weekly schedule.
+		// Just increment this number if that's the case.
+		$manual_version = '1';
+
+		// Base URL for bilmur script.
+		$bilmur_url = 'https://s0.wp.com/wp-content/js/bilmur.min.js';
+
+		wp_enqueue_script( 'bilmur', $bilmur_url . '?' . $weekly_cachebust, array(), $manual_version, array( 'strategy' => 'defer', 'in_footer' => true ) );
 	}
 );
 
-add_filter(
-	'script_loader_tag',
-	function( $tag, $handle ) {
-		if ( 'bilmur' === $handle ) {
-			if ( defined( 'WPCOMSP_BILMUR_PROVIDER' ) ) {
-				$tag = str_replace( ' src', ' data-provider="' . WPCOMSP_BILMUR_PROVIDER . '" src', $tag );
-			}
-			if ( defined( 'WPCOMSP_BILMUR_SERVICE' ) ) {
-				$tag = str_replace( ' src', ' data-service="' . WPCOMSP_BILMUR_SERVICE . '" src', $tag );
-			}
-			if ( defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) ) {
-				$tag = str_replace( ' src', ' data-customproperties="' . wp_json_encode( WPCOMSP_BILMUR_CUSTOM_PROPERTIES ) . '" src', $tag );
-			}
-		}
+// Add bilmur config to page for the script to pick up when it runs.
+add_action(
+	'wp_footer',
+	function() {
+		$custom_properties = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
 
-		return $tag;
-	},
-	10,
-	2
+		// Is the WooCommerce plugin active?
+		$woo_active = class_exists( 'WooCommerce' ) ? '1' : '0';
+		$custom_properties['woo_active'] = $woo_active;
+
+		?>
+			<meta
+				id="bilmur"
+				property="bilmur:data"
+				content=""
+				data-provider="<?php echo esc_attr( WPCOMSP_BILMUR_PROVIDER ) ?>"
+				data-service="<?php echo esc_attr( WPCOMSP_BILMUR_SERVICE ) ?>"
+				data-custom-props="<?php echo esc_attr( wp_json_encode( $custom_properties ) ) ?>"
+				data-site-tz="<?php echo esc_attr( wpcomsp_bilmur_timezone_string() ) ?>"
+			>
+		<?php
+	}
 );

--- a/includes/bilmur.php
+++ b/includes/bilmur.php
@@ -7,6 +7,11 @@ if ( ! defined( 'WPCOMSP_BILMUR_TRACKING' ) || ! WPCOMSP_BILMUR_TRACKING ) {
 	return;
 }
 
+// Only load if a provider and service have been configured.
+if ( ! defined( 'WPCOMSP_BILMUR_PROVIDER' ) || ! defined( 'WPCOMSP_BILMUR_SERVICE' ) ) {
+	return;
+}
+
 // Returns a standardized timezone string.
 //
 // `wp_timezone_string()` sometimes returns offsets (e.g. "-07:00"), which are
@@ -97,10 +102,6 @@ add_action(
 	'wp_footer',
 	function () {
 		$custom_properties = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
-
-		if ( ! defined( 'WPCOMSP_BILMUR_PROVIDER' ) || ! defined( 'WPCOMSP_BILMUR_SERVICE' ) ) {
-			return;
-		}
 
 		// Is the WooCommerce plugin active?
 		$woo_active = class_exists( 'WooCommerce' ) ? '1' : '0';


### PR DESCRIPTION
Hey folks! 👋

This PR improves the Bilmur tracking in a number of ways:

- It adds a weekly cachebust to ensure new bilmur versions are automatically picked up
- It defers the bilmur script, so that it runs later in the page loading process, freeing up other footer scripts to run first
- It moves the configuration to a `<meta>` tag, avoiding the need to use `script_loader_tag` to rewrite the script tag, and making it less likely for optimiser plugins to inadvertently remove the configuration
- It adds support for the site timezone config
- It automatically adds a `woo_active` that reflects whether the WooCommerce plugin is active

Please take a look and let me know what you think!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added standardized timezone handling for site data, improving consistency in timezone representation.
  - Introduced a meta tag in the page footer containing configuration data, including provider, service, custom properties, WooCommerce status, and timezone.

- **Improvements**
  - Enhanced script loading with weekly cache-busting and manual versioning for more reliable updates.
  - Updated script loading strategy for better performance.

- **Removals**
  - Removed injection of configuration data into script tags in favor of a meta tag approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->