### PR TITLE
Allow bilmur to work with WP Rocket active

### DIFF
--- a/includes/bilmur.php
+++ b/includes/bilmur.php
@@ -97,6 +97,31 @@ add_action(
 	}
 );
 
+// The WP Rocket feature `Delay JavaScript Execution` prevents the bilmur
+// beacon with the performance data from being sent.  This looks to see if
+// the WP Rocket plugin is active and when it is adds the `nowprocket`
+// attribute to the bilmur script tag.  This tells WP Rocket to skip trying
+// to delay running this script, which allows use to still collect performance
+// data.
+//
+// https://docs.wp-rocket.me/article/1349-delay-javascript-execution
+function wpcomsh_bilmur_script_tag( $tag, $handle, $src ) {
+	if ( $handle != 'bilmur' ) {
+		return $tag;
+	}
+
+	$tag = str_replace( 'id="bilmur-js"', 'id="bilmur-js" nowprocket', $tag );
+	return $tag;
+};
+
+function wpcomsh_bilmur_after_plugins() {
+	$all_plugins = get_option( 'active_plugins' );
+	if ( false !== array_search( 'wp-rocket/wp-rocket.php', $all_plugins ) ) {
+		add_filter( 'script_loader_tag', 'wpcomsh_bilmur_script_tag', 10, 3 );
+	}
+}
+add_action( 'plugins_loaded', 'wpcomsh_bilmur_after_plugins' );
+
 // Add bilmur config to page for the script to pick up when it runs.
 add_action(
 	'wp_footer',

--- a/includes/bilmur.php
+++ b/includes/bilmur.php
@@ -101,7 +101,7 @@ add_action(
 // beacon with the performance data from being sent.  This looks to see if
 // the WP Rocket plugin is active and when it is adds the `nowprocket`
 // attribute to the bilmur script tag.  This tells WP Rocket to skip trying
-// to delay running this script, which allows use to still collect performance
+// to delay running this script, which allows us to still collect performance
 // data.
 //
 // https://docs.wp-rocket.me/article/1349-delay-javascript-execution

--- a/includes/bilmur.php
+++ b/includes/bilmur.php
@@ -105,19 +105,17 @@ add_action(
 // data.
 //
 // https://docs.wp-rocket.me/article/1349-delay-javascript-execution
-function wpcomsh_bilmur_script_tag( $tag, $handle, $src ) {
-	if ( $handle != 'bilmur' ) {
-		return $tag;
-	}
-
-	$tag = str_replace( 'id="bilmur-js"', 'id="bilmur-js" nowprocket', $tag );
-	return $tag;
+function wpcomsh_bilmur_script_attributes( array $attributes ) {
+    if ( !empty( $attributes['id'] ) && 'bilmur-js' === $attributes['id'] ) {
+        $attributes['nowprocket'] = true;
+    }
+    return $attributes;
 };
 
 function wpcomsh_bilmur_after_plugins() {
 	$all_plugins = get_option( 'active_plugins' );
 	if ( false !== array_search( 'wp-rocket/wp-rocket.php', $all_plugins ) ) {
-		add_filter( 'script_loader_tag', 'wpcomsh_bilmur_script_tag', 10, 3 );
+		add_filter( 'wp_script_attributes', 'wpcomsh_bilmur_script_attributes', 10, 1 );
 	}
 }
 add_action( 'plugins_loaded', 'wpcomsh_bilmur_after_plugins' );


### PR DESCRIPTION
The WP Rocket feature `Delay JavaScript Execution` prevents the bilmur beacon with the performance data from being sent.  This looks to see if the WP Rocket plugin is active and when it is adds the `nowprocket` attribute to the bilmur script tag.  This tells WP Rocket to skip trying to delay running this script, which allows use to still collect performance data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic WP Rocket compatibility: bilmur now detects WP Rocket and marks its script to bypass the “Delay JavaScript Execution” behavior when present.
  * No user action required; applied only when WP Rocket is active.

* **Bug Fixes**
  * Prevents delayed or inconsistent bilmur loading on sites using WP Rocket’s JS delay feature, improving interactivity and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->